### PR TITLE
UDP Packet sent to GitHub for ip address lookup

### DIFF
--- a/lib/sysinfo.rb
+++ b/lib/sysinfo.rb
@@ -3,25 +3,25 @@ require 'storable'
 require 'time'
 
 # = SysInfo
-# 
-# A container for the platform specific system information. 
-# Portions of this code were originally from Amazon's EC2 AMI tools, 
-# specifically lib/platform.rb. 
+#
+# A container for the platform specific system information.
+# Portions of this code were originally from Amazon's EC2 AMI tools,
+# specifically lib/platform.rb.
 class SysInfo < Storable
   unless defined?(IMPLEMENTATIONS)
     VERSION = "0.8.0".freeze
     IMPLEMENTATIONS = [
-    
-      # These are for JRuby, System.getproperty('os.name'). 
+
+      # These are for JRuby, System.getproperty('os.name').
       # For a list of all values, see: http://lopica.sourceforge.net/os.html
-      
+
       #regexp matcher       os        implementation
-      [/mac\s*os\s*x/i,     :unix,    :osx              ],  
-      [/sunos/i,            :unix,    :solaris          ], 
+      [/mac\s*os\s*x/i,     :unix,    :osx              ],
+      [/sunos/i,            :unix,    :solaris          ],
       [/windows\s*ce/i,     :windows, :wince            ],
-      [/windows/i,          :windows, :windows          ],  
+      [/windows/i,          :windows, :windows          ],
       [/osx/i,              :unix,    :osx              ],
-      
+
       # These are for RUBY_PLATFORM and JRuby
       [/java/i,             :java,    :java             ],
       [/darwin/i,           :unix,    :osx              ],
@@ -63,14 +63,14 @@ class SysInfo < Storable
   field :ipaddress_internal => String
   #field :ipaddress_external => String
   field :uptime => Float
-  
+
   field :paths
   field :tmpdir
   field :home
   field :shell
   field :user
   field :ruby
-  
+
   alias :implementation :impl
   alias :architecture :arch
 
@@ -81,7 +81,7 @@ class SysInfo < Storable
     @user = ENV['USER']
     require 'Win32API' if @os == :windows && @vm == :ruby
   end
-  
+
   # Returns [vm, os, impl, arch]
   def find_platform_info
     vm, os, impl, arch = :ruby, :unknown, :unknown, :unknow
@@ -97,25 +97,25 @@ class SysInfo < Storable
     end
     os == :java ? guess_java : [vm, os, impl, arch]
   end
-  
+
   # Returns [hostname, ipaddr (internal), uptime]
   def find_network_info
     hostname, ipaddr, uptime = :unknown, :unknown, :unknown
     begin
       hostname = find_hostname
       ipaddr = find_ipaddress_internal
-      uptime = find_uptime       
+      uptime = find_uptime
     rescue => ex # Be silent!
     end
     [hostname, ipaddr, uptime]
   end
-  
+
     # Return the hostname for the local machine
   def find_hostname; Socket.gethostname; end
-  
-  # Returns the local uptime in hours. Use Win32API in Windows, 
+
+  # Returns the local uptime in hours. Use Win32API in Windows,
   # 'sysctl -b kern.boottime' os osx, and 'who -b' on unix.
-  # Based on Ruby Quiz solutions by: Matthias Reitinger 
+  # Based on Ruby Quiz solutions by: Matthias Reitinger
   # On Windows, see also: net statistics server
   def find_uptime
     hours = 0
@@ -128,24 +128,19 @@ class SysInfo < Storable
     hours
   end
 
-  
-  # Return the local IP address which receives external traffic
-  # from: http://coderrr.wordpress.com/2008/05/28/get-your-local-ip-address/
-  # NOTE: This <em>does not</em> open a connection to the IP address. 
+
+  # Return the first local IPv4 address without creating a UDP ping on Github
   def find_ipaddress_internal
-    # turn off reverse DNS resolution temporarily 
-    orig, Socket.do_not_reverse_lookup = Socket.do_not_reverse_lookup, true   
-    UDPSocket.open {|s| s.connect('65.74.177.129', 1); s.addr.last } # GitHub IP
-  ensure  
-    Socket.do_not_reverse_lookup = orig
+    first_nic = Socket.ip_address_list.detect{|intf| intf.ipv4_private?}
+    first_nic.ip_address
   end
-  
+
   # Returns a String of the full platform descriptor in the format: VM-OS-IMPL-ARCH
   # e.g. <tt>java-unix-osx-x86_64</tt>
   def platform
     "#{@vm}-#{@os}-#{@impl}-#{@arch}"
   end
-  
+
     # Returns the environment paths as an Array
   def paths; execute_platform_specific(:paths); end
     # Returns the path to the current user's home directory
@@ -154,10 +149,10 @@ class SysInfo < Storable
   def shell; execute_platform_specific(:shell); end
     # Returns the path to the current temp directory
   def tmpdir; execute_platform_specific(:tmpdir); end
-  
+
  private
-  
-  # Look for and execute a platform specific method. 
+
+  # Look for and execute a platform specific method.
   # The name of the method will be in the format: +dtype-VM-OS-IMPL+.
   # e.g. find_uptime_ruby_unix_osx
   #
@@ -168,28 +163,28 @@ class SysInfo < Storable
       return self.send(meth) if SysInfo.private_method_defined?(meth)
       criteria.pop
     end
-    raise "#{dtype}_#{@vm}_#{@os}_#{@impl} not implemented" 
+    raise "#{dtype}_#{@vm}_#{@os}_#{@impl} not implemented"
   end
-  
+
   def paths_ruby_unix; (ENV['PATH'] || '').split(':'); end
   def paths_ruby_windows; (ENV['PATH'] || '').split(';'); end # Not tested!
   def paths_java
     delim = @impl == :windows ? ';' : ':'
     (ENV['PATH'] || '').split(delim)
   end
-  
+
   def tmpdir_ruby_unix; (ENV['TMPDIR'] || '/tmp'); end
   def tmpdir_ruby_windows; (ENV['TMPDIR'] || 'C:\\temp'); end
   def tmpdir_java
     default = @impl == :windows ? 'C:\\temp' : '/tmp'
     (ENV['TMPDIR'] || default)
   end
-  
+
   def shell_ruby_unix; (ENV['SHELL'] || 'bash').to_sym; end
   def shell_ruby_windows; :dos; end
   alias_method :shell_java_unix, :shell_ruby_unix
   alias_method :shell_java_windows, :shell_ruby_windows
-  
+
   def home_ruby_unix; File.expand_path(ENV['HOME']); end
   def home_ruby_windows; File.expand_path(ENV['USERPROFILE']); end
   def home_java
@@ -199,9 +194,9 @@ class SysInfo < Storable
       File.expand_path(ENV['HOME'])
     end
   end
-  
+
   # Ya, this is kinda wack. Ruby -> Java -> Kernel32. See:
-  # http://www.oreillynet.com/ruby/blog/2008/01/jruby_meets_the_windows_api_1.html  
+  # http://www.oreillynet.com/ruby/blog/2008/01/jruby_meets_the_windows_api_1.html
   # http://msdn.microsoft.com/en-us/library/ms724408(VS.85).aspx
   # Ruby 1.9.1: Win32API is now deprecated in favor of using the DL library.
   def find_uptime_java_windows_windows
@@ -215,30 +210,30 @@ class SysInfo < Storable
     ((getTickCount.call()).to_f / 1000).to_f
   end
   def find_uptime_ruby_unix_osx
-    # This is faster than "who" and could work on BSD also. 
+    # This is faster than "who" and could work on BSD also.
     (Time.now.to_f - Time.at(`sysctl -b kern.boottime 2>/dev/null`.unpack('L').first).to_f).to_f
   end
-  
+
   # This should work for most unix flavours.
   def find_uptime_ruby_unix
     # who is sloooooow. Use File.read('/proc/uptime')
     (Time.now.to_i - Time.parse(`who -b 2>/dev/null`).to_f)
   end
   alias_method :find_uptime_java_unix_osx, :find_uptime_ruby_unix
-  
-  # Determine the values for vm, os, impl, and arch when running on Java. 
+
+  # Determine the values for vm, os, impl, and arch when running on Java.
   def guess_java
     vm, os, impl, arch = :java, :unknown, :unknown, :unknown
     require 'java'
     include_class java.lang.System unless defined?(System)
-    
+
     osname = System.getProperty("os.name")
     IMPLEMENTATIONS.each do |r, o, i|
       next unless osname =~ r
       os, impl = [o, i]
       break
     end
-    
+
     osarch = System.getProperty("os.arch")
     ARCHITECTURES.each do |r, a|
       next unless osarch =~ r
@@ -247,12 +242,12 @@ class SysInfo < Storable
     end
     [vm, os, impl, arch]
   end
-  
-  # Returns the local IP address based on the hostname. 
+
+  # Returns the local IP address based on the hostname.
   # According to coderrr (see comments on blog link above), this implementation
   # doesn't guarantee that it will return the address for the interface external
   # traffic goes through. It's also possible the hostname isn't resolvable to the
-  # local IP.  
+  # local IP.
   #
   # NOTE: This code predates the current ip_address_internal. It was just as well
   # but the other code is cleaner. I'm keeping this old version here for now.


### PR DESCRIPTION
While I admire the method that is being used to lookup the system's local IP address, I thought I'd try another way and see what you think.  UDP is pretty cheap but I'd feel better if I didn't ping GitHub every time I did something with a downstream library that uses `SysInfo.new`.

The current method (UDP) relies on IPv4 anyway.  So what do you think of the attached change?  Too simple?
