### PR TITLE
Replace deprecated include_class by java_import

### DIFF
--- a/lib/sysinfo.rb
+++ b/lib/sysinfo.rb
@@ -231,7 +231,7 @@ class SysInfo < Storable
   def guess_java
     vm, os, impl, arch = :java, :unknown, :unknown, :unknown
     require 'java'
-    include_class java.lang.System unless defined?(System)
+    java_import java.lang.System unless defined?(System)
     
     osname = System.getProperty("os.name")
     IMPLEMENTATIONS.each do |r, o, i|


### PR DESCRIPTION
Using include_class generates a warning with  jruby >= 1.7 and might be deprecated with jruby 1.8 ([see](http://jira.codehaus.org/browse/JRUBY-3797))
