### PR TITLE
Update supported architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,35 +45,38 @@ sysinfo.ruby                  # => [1,9,1]
 ## Usage -- Executable
 
 ```bash
-$ sysinfo
-ruby-unix-osx-i386
+  $ sysinfo
+  ruby-unix-osx-i386
 
-$ /usr/jruby/bin/sysinfo
-java-unix-osx-x86_64
+  $ /usr/jruby/bin/sysinfo
+  java-unix-osx-x86_64
 
-$ sysinfo -f yaml
-:vm: :ruby
-:os: :unix
-:impl: :osx
-...
-:shell: :"/bin/bash"
-:user: delano
+  $ sysinfo -f yaml
+  :vm: :ruby
+  :os: :unix
+  :impl: :osx
+  ...
+  :shell: :"/bin/bash"
+  :user: delano
 
-$ sysinfo -f json
-{"vm":"ruby","os":"unix","impl":"osx", ..., "shell":"\/bin\/bash","user":"delano"}
+  $ sysinfo -f json
+  {"vm":"ruby","os":"unix","impl":"osx", ..., "shell":"\/bin\/bash","user":"delano"}
 
-$ sysinfo -f csv
-ruby,unix,osx, ... /bin/bash,delano
+  $ sysinfo -f csv
+  ruby,unix,osx, ... /bin/bash,delano
 ```
 
 ## Installation
 
 ```bash
-    $ sudo gem install sysinfo
+  $ sudo gem install sysinfo
 ```
 
 
 ## Prerequisites
 
-* Ruby 1.9+, 2.6.8+, 3.1.4+, or JRuby 1.2+
+* Ruby 3.0.2+
+* Ruby 2.6.8+
+* Ruby 1.9+
+* JRuby 1.2+
 * [Storable](https://github.com/delano/storable)

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ SysInfo does a takes a very quick glance at the system it's running on and expos
 
 ## Platform Identifier Examples
 
-- ruby-unix-osx-i386
-- ruby-unix-osx-powerpc
+- ruby-unix-osx-arm64
+- ruby-unix-osx-x86_64
 - ruby-unix-linux-x86_64
-- java-win32-windows-i386
-- java-win32-mingw-i386
+- java-win32-windows-x86_64
+- java-win32-mingw-ia64
 
 For the complete list of operating systems, implementations and architectures that SysInfo is aware of, see:
 

--- a/bin/sysinfo
+++ b/bin/sysinfo
@@ -15,17 +15,17 @@ require 'sysinfo'
 
 module SysInfoCLI #:nodoc:
   extend Drydock
-  
+
   debug :on
   default :info
-  
+
   global :f, :format, String, "Output format. One of: yaml, json, csv, tsv, string (default)"
   global :v, :verbose, "Output everything I know"
   global :V, :version, "Display version number" do
     puts "SysInfo version: #{SysInfo::VERSION}"
     exit 0
   end
-  
+
   about "Display system information"
   command :info do |obj|
     format = obj.global.format || :string
@@ -33,44 +33,24 @@ module SysInfoCLI #:nodoc:
     si = SysInfo.new
     puts format.to_s == 'string' ? si.platform : si.dump(format)
   end
-  
+
   about "Display list of known architectures"
   command :arch do |obj|
-    arch = SysInfo::ARCHITECTURES.collect { |arch| 
-      next if arch[0].nil?
-      obj.global.verbose == true ? "%-15s -> %s" % [arch[1], arch[0].source] : arch[1] 
-    }
-    puts arch.compact
+    puts SysInfo.architectures(obj.global.verbose)
   end
   command_alias :arch, :architectures
-  
+
   about "Display list of known OS implementations"
   command :impl do |obj|
-    reorg = {}
-    SysInfo::IMPLEMENTATIONS.each do |arch| 
-      next if arch[0].nil?
-      reorg.store(arch[2].to_s, arch[0])
-    end
-    impl = reorg.keys.sort.collect do |key|
-      obj.global.verbose == true ? "%-15s -> %s" % [key, reorg[key].source] : key
-    end
-    puts impl.compact.uniq
+    puts SysInfo.implementations(obj.global.verbose)
   end
   command_alias :impl, :implementations
-  
-  about "Display list of known operating systems (OS)"
+
+  about "Display list of known operating system families"
   command :os do |obj|
-    reorg = {}
-    SysInfo::IMPLEMENTATIONS.each do |arch| 
-      next if arch[0].nil?
-      reorg.store(arch[1].to_s, arch[0])
-    end
-    impl = reorg.keys.sort.collect do |key|
-      obj.global.verbose == true ? "%-15s -> %s" % [key, reorg[key].source] : key
-    end
-    puts impl.compact.uniq
+    puts SysInfo.os_families(obj.global.verbose)
   end
-  
+
 end
 
 Drydock.run!(ARGV, STDIN) if Drydock.run? && !Drydock.has_run?

--- a/lib/sysinfo.rb
+++ b/lib/sysinfo.rb
@@ -315,6 +315,7 @@ class SysInfo < Storable
     passwd[pwattr]
   end
 end
+Sysinfo = SysInfo # add alias for common styling
 
 
 if $0 == __FILE__

--- a/lib/sysinfo.rb
+++ b/lib/sysinfo.rb
@@ -50,9 +50,14 @@ class SysInfo < Storable
       [/alpha/i,    :alpha            ],
       [/sparc/i,    :sparc            ],
       [/mips/i,     :mips             ],
+      [/ppc64/i,    :ppc64            ],
       [/powerpc/i,  :powerpc          ],
+      [/ppc/i,      :powerpc          ],
       [/universal/i,:x86_64           ],
       [/arm64/i,    :arm64            ],
+      [/aarch64/i,  :arm64            ],
+      [/arm32/i,    :arm32            ],
+      [/armv7l/i,   :arm32            ],
       [nil,         :unknown          ],
     ].freeze
   end

--- a/lib/sysinfo.rb
+++ b/lib/sysinfo.rb
@@ -11,8 +11,8 @@ require 'tmpdir'
 class SysInfo < Storable
   unless defined?(IMPLEMENTATIONS)
     VERSION = "0.10.0".freeze
-    IMPLEMENTATIONS = [
 
+    IMPLEMENTATIONS = [
       # These are for JRuby, System.getproperty('os.name').
       # For a list of all values, see: http://lopica.sourceforge.net/os.html
 
@@ -160,6 +160,41 @@ class SysInfo < Storable
   def shell; execute_platform_specific(:shell); end
     # Returns the path to the current temp directory
   def tmpdir; execute_platform_specific(:tmpdir); end
+
+
+  class << self
+    def architectures verbose=false
+      arch = SysInfo::ARCHITECTURES.collect { |arch|
+        next if arch[0].nil?
+        verbose ? "%-15s -> %s" % [arch[0].source, arch[1]] : arch[1]
+      }
+      arch.compact.sort
+    end
+
+    def implementations verbose=false
+      reorg = {}
+      SysInfo::IMPLEMENTATIONS.each do |impl|
+        next if impl[0].nil?
+        reorg.store(impl[2].to_s, impl[0])
+      end
+      impl = reorg.keys.sort.collect do |key|
+        verbose ? "%-15s -> %s" % [reorg[key].source, key] : key
+      end
+      impl.compact.uniq
+    end
+
+    def os_families verbose=false
+      reorg = {}
+      SysInfo::IMPLEMENTATIONS.each do |syst|
+        next if syst[0].nil?
+        reorg.store(syst[1].to_s, syst[0])
+      end
+      impl = reorg.keys.sort.collect do |key|
+        verbose ? "%-15s -> %s" % [reorg[key].source, key] : key
+      end
+      impl.compact.uniq
+    end
+  end
 
  private
 

--- a/try/10_basic_try.rb
+++ b/try/10_basic_try.rb
@@ -22,3 +22,15 @@ output = si.dump(:yaml)
 parsed = YAML.load(output)
 parsed.keys.sort
 #=> [:arch, :home, :hostname, :impl, :ipaddress_internal, :os, :paths, :ruby, :shell, :tmpdir, :uptime, :user, :vm]
+
+## Has architectures
+SysInfo.architectures
+#=> [:alpha, :arm32, :arm32, :arm64, :arm64, :ia64, :mips, :powerpc, :powerpc, :ppc64, :sparc, :x86, :x86, :x86_64, :x86_64]
+
+## Has implementations
+SysInfo.implementations
+#=> ["bccwin", "cygwin", "djgpp", "freebsd", "irix", "java", "linux", "mingw", "netbsd", "os2", "osx", "solaris", "vms", "wince", "windows"]
+
+## Has os_families
+SysInfo.os_families
+#=> ["java", "os2", "unix", "vms", "windows"]

--- a/try/10_basic_try.rb
+++ b/try/10_basic_try.rb
@@ -1,0 +1,24 @@
+require_relative '../lib/sysinfo'
+
+require 'yaml'
+require 'json'
+
+
+## Can output platform as a string
+si = SysInfo.new
+si.platform
+#=> 'ruby-unix-osx-arm64'
+
+## Can output platform as json
+si = SysInfo.new
+output = si.dump(:json)
+parsed = JSON.parse(output)
+parsed.keys.sort
+#=> ["arch", "home", "hostname", "impl", "ipaddress_internal", "os", "paths", "ruby", "shell", "tmpdir", "uptime", "user", "vm"]
+
+## Can output platform as yaml
+si = SysInfo.new
+output = si.dump(:yaml)
+parsed = YAML.load(output)
+parsed.keys.sort
+#=> [:arch, :home, :hostname, :impl, :ipaddress_internal, :os, :paths, :ruby, :shell, :tmpdir, :uptime, :user, :vm]


### PR DESCRIPTION
Additional processor architectures are now supported by SysInfo including PowerPC, ARM, and Aarch64. The regular expressions used to match processor names from sys_info were updated to correctly identify these systems.

This pull request also improves the command line interface by updating the help text for the `arch`, `impl`, and `os` commands to accurately reflect the listings they display. The implementation of these commands has been refactored to call methods on the `SysInfo` class, reducing duplicated logic. Additionally, a class alias `Sysinfo` has been added for common reference style. The README has been updated with example calls to demonstrate the new command line interface.